### PR TITLE
Adds async script loading options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ make it easy to compose markers into your map instances.
 #### Properties
 
 * `apiKey:String` **Required** - Google Maps Javascript API key. [Guide to get an API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
+* `async:Bool` - True loads Google Maps script asynchronously. Defaults to true.
 * `options:Object` - Options for customizing/styling the map. [MapOptions Interface](https://google-developers.appspot.com/maps/documentation/javascript/reference/3.exp/map#MapOptions)
 * `onReady:Function` - Called when the Google Maps script has initialized `(map) => {}`
 * `onBoundsChange:Function` - Called when the `bounds_changed` event is fired from the map. `(map) => {}`

--- a/src/GoogleMap.js
+++ b/src/GoogleMap.js
@@ -179,6 +179,8 @@ class GoogleMap extends Component {
           <Script
             url={`https://maps.googleapis.com/maps/api/js?key=${apiKey}&callback=reactMapsGoogleInit`}
             onLoad={this.onScriptLoad}
+            async={this.props.async ? `async` : false}
+            defer={this.props.defer ? `defer` : false}
           />
         )}
         <div
@@ -194,6 +196,7 @@ class GoogleMap extends Component {
 
 GoogleMap.propTypes = {
   apiKey: PropTypes.string.isRequired,
+  async: PropTypes.bool,
   options: PropTypes.object,
   onBoundsChange: PropTypes.func,
   onCenterChange: PropTypes.func,
@@ -224,6 +227,7 @@ GoogleMap.defaultProps = {
     },
     zoom: 12,
   },
+  async: true,
   onBoundsChange: () => {},
   onCenterChange: () => {},
   onClick: () => {},


### PR DESCRIPTION
Adds `async` and `defer` by default to speed page load. In accordance with: https://medium.com/@nikjohn/speed-up-google-maps-and-everything-else-with-async-defer-7b9814efb2b